### PR TITLE
Fix format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ help:
 test:  ## Run tests, linting, and static typechecking
 	tox
 
+.PHONY: format
+format:  ## Format files
+	tox exec -e py38-lint -- ruff format
+
 .PHONY: lint
-lint:  ## Lint and black reformat files
-	# NOTE(willkg): Make sure this matches what's in tox.ini.
-	black setup.py fx_crash_sig tests
+lint:  ## Lint files
 	tox -e py38-lint
 
 .PHONY: clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,6 @@ commands = pytest {posargs} tests/
 basepython = python3.8
 changedir = {toxinidir}
 commands =
-    ruff format setup.py fx_crash_sig tests
+    ruff format --check setup.py fx_crash_sig tests
     ruff check setup.py fx_crash_sig tests
 """


### PR DESCRIPTION
This adds a "format" make rule to run "ruff format" so we can format Python files in a local dev environment.

It also fixes the py38-lint tox environment to run "ruff format --check" so formatting issues error out in CI.