### PR TITLE
Remove reviewers from Dependabot configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "obs-team"
     rebase-strategy: "disabled"


### PR DESCRIPTION
The Dependabot PRs get assigned to mozilla-services/obs-team automatically due to our branch protection rules, so we don't need a reviewer in the Dependabot configuration. Moreover, the current configuration tried to assign the PRs to https://github.com/obs-team, which is different from https://github.com/orgs/mozilla-services/teams/obs-team.